### PR TITLE
Show processing orders in market liabilities query (not working)

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -2612,6 +2612,14 @@ WHERE
 AND
  (orders.canceled_by_seller OR orders.canceled_by_buyer)
 UNION ALL
+select orders.buyer_user_id as user_id, orders.amount_owed_sat as amount_change_sat, 'processing_order' as event_type, orders.public_id as event_id, orders.created_time_ms as event_time_ms
+from
+ orders
+WHERE
+ orders.paid
+AND
+ NOT (orders.shipped OR orders.canceled_by_seller OR orders.canceled_by_buyer)
+UNION ALL
 select withdrawals.user_id as user_id, (0 - withdrawals.amount_sat) as amount_change_sat, 'withdrawal' as event_type, withdrawals.public_id as event_id, withdrawals.created_time_ms as event_time_ms
 from
  withdrawals)


### PR DESCRIPTION
This is currently failing:
```
yzernik@yzernik-MacBookPro:~/work/squeakroad$ cargo sqlx prepare --database-url sqlite://db.sqlite
   Compiling squeakroad v0.0.2 (/home/yzernik/work/squeakroad)
error: unsupported type NULL of column #2 ("amount_change_sat")
    --> src/models.rs:2597:39
     |
2597 |           let account_balance_changes = sqlx::query!("
     |  _______________________________________^
2598 | | SELECT * FROM
2599 | | (select orders.seller_user_id as user_id, orders.seller_credit_sat as amount_change_sat, 'received_order' as event_type, orders.public_id...
2600 | | from
...    |
2628 | | OFFSET ?
2629 | | ;", limit, offset)
     | |__________________^
     |
     = note: this error originates in the macro `$crate::sqlx_macros::expand_query` (in Nightly builds, run with -Z macro-backtrace for more info)

error: unsupported type NULL of column #3 ("event_type")
    --> src/models.rs:2597:39
     |
2597 |           let account_balance_changes = sqlx::query!("
     |  _______________________________________^
2598 | | SELECT * FROM
2599 | | (select orders.seller_user_id as user_id, orders.seller_credit_sat as amount_change_sat, 'received_order' as event_type, orders.public_id...
2600 | | from
...    |
2628 | | OFFSET ?
2629 | | ;", limit, offset)
     | |__________________^
     |
     = note: this error originates in the macro `$crate::sqlx_macros::expand_query` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `unwrap` found for struct `std::string::String` in the current scope
    --> src/models.rs:2634:42
     |
2634 |                     event_id: r.event_id.unwrap(),
     |                                          ^^^^^^ method not found in `std::string::String`

error[E0599]: no method named `unwrap` found for type `i64` in the current scope
    --> src/models.rs:2635:52
     |
2635 |                     event_time_ms: r.event_time_ms.unwrap().try_into().unwrap(),
     |                                                    ^^^^^^ method not found in `i64`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `squeakroad` due to 4 previous errors
error: `cargo check` failed with status: exit status: 101
```