### PR TITLE
Revert "Add linux/x86_64 as a platform for docker image build (#561)"

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -61,7 +61,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/arm64,linux/amd64,linux/x86_64
+          platforms: linux/arm64,linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
This reverts commit a2b37f77c23396a095cf27850dc57535ab131164.